### PR TITLE
Minor plot enhancements from run 2022/2

### DIFF
--- a/src/metro/devices/display/fast_plot.py
+++ b/src/metro/devices/display/fast_plot.py
@@ -172,6 +172,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         self.stacking = state.pop('stacking', 0.0)
         self.show_marker = state.pop('show_marker', args['show_marker'])
         self.show_legend = state.pop('show_legend', True)
+        self.show_annotations = state.pop('show_annotations', True)
         self.downsampling = state.pop('downsampling', args['downsampling'])
 
         if lttbc is None:
@@ -313,6 +314,11 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         self.actionShowLegend.setCheckable(True)
         self.actionShowLegend.setChecked(self.show_legend)
 
+        self.actionShowAnnotations = self.menuContext.addAction(
+            'Show annotations')
+        self.actionShowAnnotations.setCheckable(True)
+        self.actionShowAnnotations.setChecked(self.show_annotations)
+
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.on_menuContext_requested)
 
@@ -384,6 +390,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
             'stacking': self.stacking,
             'show_marker': self.show_marker,
             'show_legend': self.show_legend,
+            'show_annotations': self.show_annotations,
             'downsampling': self.downsampling
         }
 
@@ -528,7 +535,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         p.setPen(self.lines_color)
 
         # Vertical annotation lines.
-        if self.vlines is not None:
+        if self.vlines is not None and self.show_annotations:
             div = self.plot_transform[0]
             y_end = -self.plot_geometry[3]
 
@@ -557,7 +564,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
             p.restore()
 
         # Horizontal annotation lines.
-        if self.hlines is not None:
+        if self.hlines is not None and self.show_annotations:
             div = self.plot_transform[1]
             x_end = self.plot_geometry[2]
 
@@ -1105,6 +1112,10 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         elif action == self.actionShowLegend:
             self.show_legend = self.actionShowLegend.isChecked()
             super().repaint()  # Trigger direct repaint as nothing is cached.
+
+        elif action == self.actionShowAnnotations:
+            self.show_annotations = self.actionShowAnnotations.isChecked()
+            super().repaint()
 
     # @metro.QSlot(QtCore.QAction)
     def on_menuDownsampling_triggered(self, action):

--- a/src/metro/devices/display/fast_plot.py
+++ b/src/metro/devices/display/fast_plot.py
@@ -304,6 +304,11 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
 
         self.menuContext.addSeparator()
 
+        self.actionTitleColor = self.menuContext.addAction(
+            'Set plot title color...')
+
+        self.menuContext.addSeparator()
+
         self.actionShowMarker = self.menuContext.addAction(
             'Show point markers')
         self.actionShowMarker.setCheckable(True)
@@ -1104,6 +1109,17 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
             self.stacking_outp = None
 
             self.dataAdded(self.ch_data)
+
+        elif action == self.actionTitleColor:
+            new_color = QtWidgets.QColorDialog.getColor(
+                self.title_color, None, self.windowTitle(),
+                QtWidgets.QColorDialog.ShowAlphaChannel)
+
+            if new_color is None:
+                return
+
+            self.title_color = new_color
+            self.repaint(title_changed=True)
 
         elif action == self.actionShowMarker:
             self.show_marker = self.actionShowMarker.isChecked()

--- a/src/metro/devices/display/image.py
+++ b/src/metro/devices/display/image.py
@@ -203,7 +203,6 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         if isinstance(d, xr.DataArray):
             axis_order = d.attrs.get('axis_order', self.axis_order)
             if axis_order not in Device.arguments['axis_order']:
-                # Make sure a valid axis order was supplied.
                 axis_order = self.axis_order
 
             x_axis_idx, y_axis_idx = self._get_axis_idx(axis_order)
@@ -223,8 +222,6 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
             y = np.arange(d.shape[y_axis_idx])
 
         elif self.history_streak > 0:
-            # TODO: xarray support for coordinates.
-
             d = np.squeeze(d)
 
             # Remove any additional axes

--- a/src/metro/devices/display/value.py
+++ b/src/metro/devices/display/value.py
@@ -12,7 +12,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice):
 
     arguments = {
         'channel': metro.ChannelArgument(),
-        'func': ('str', 'repr', 'pprint')
+        'func': ('str', 'repr', 'pprint', 'ndshape')
     }
 
     descriptions = {
@@ -46,6 +46,8 @@ class Device(metro.WidgetDevice, metro.DisplayDevice):
 
             pretty_printer = pprint.PrettyPrinter(indent=4)
             self.display_func = pretty_printer.pformat
+        elif args['func'] == 'ndshape':
+            self.display_func = lambda x: str(x.shape)
 
         self.channel = args['channel']
         self.channel.subscribe(self)

--- a/src/metro/devices/display/waveform.py
+++ b/src/metro/devices/display/waveform.py
@@ -7,6 +7,7 @@
 import collections
 
 import numpy
+import xarray as xr
 
 import metro
 from metro.devices.abstract import single_plot
@@ -55,6 +56,7 @@ class Device(single_plot.Device, metro.DisplayDevice):
             self.raw_enabled = True
             self.ma_enabled = args['ma_enabled']
 
+        self.y_label = ''
         self.x_data = None
         self.y_data = []
         self.ma_buffer = collections.deque(maxlen=self.ma_points)
@@ -220,6 +222,13 @@ class Device(single_plot.Device, metro.DisplayDevice):
     def dataAdded(self, d):
         if d is None:
             return
+        elif isinstance(d, xr.DataArray):
+            y_label = d.attrs.get('ylabel', None) or ''
+            if y_label != self.y_label:
+                self.plot_item.setLabel('left', y_label)
+                self.y_label = y_label
+
+            d = float(d.data)
 
         try:
             d = d[self.index]


### PR DESCRIPTION
A set of small and miscellaneous improvements across several `display` devices developed during run 2022/2.

* Add show annotations toggle to `display.fast_plot`
* Add dialog to customize background title color in `display.fast_plot`
* Add function to display `ndarray` shape to `display.value`
* Remove no longer relevant comments in `display.image`
* Add `xarray` support with custom y label attribute to `display.waveform`