### PR TITLE
Handle NaN in display devices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -6,35 +6,17 @@
 
 import subprocess
 
-from setuptools import Distribution, setup, find_packages
+from setuptools import setup, find_packages
 from setuptools.extension import Extension
-
-# Fetch numpy and Cython as build dependencies.
-Distribution().fetch_build_eggs(['numpy', 'Cython'])
 
 # Safe to import here after line above.
 import numpy
 from Cython.Build import cythonize
 
 
-def find_version():
-    try:
-        short_hash = subprocess.check_output(
-            ['git', 'rev-parse', '--short', 'HEAD'],
-            stderr=subprocess.STDOUT
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return None
-    else:
-        if short_hash.startswith(b'fatal'):
-            return None
-        else:
-            return short_hash.decode('ascii').strip()
-
-
 setup(
     name='metro-sci',
-    version=find_version() or 'dev',
+    version='1.0.0',
     author='Philipp Schmidt',
     author_email='philipp.schmidt@xfel.eu',
     description='Framework for experimental control, data acquisition and '

--- a/src/metro/devices/abstract/single_plot.py
+++ b/src/metro/devices/abstract/single_plot.py
@@ -5,7 +5,7 @@
 
 
 import metro
-from metro.external import pyqtgraph
+import pyqtgraph
 
 
 class Device(metro.WidgetDevice, metro.DisplayDevice):

--- a/src/metro/devices/display/fast_plot.py
+++ b/src/metro/devices/display/fast_plot.py
@@ -1235,8 +1235,11 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
     def dataAdded(self, d):
         self.ch_data = d
 
+        nan_replacement = 0
         if isinstance(self.ch_data, xr.DataArray):
             self.idx_data = self.ch_data.data[self.index]
+            if "replace_nan" in self.ch_data.attrs:
+                nan_replacement = self.ch_data.attrs["replace_nan"]
 
             if self.idx_data.ndim == 1:
                 self.idx_data = self.idx_data[None, :]
@@ -1267,6 +1270,9 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
 
         if self.idx_data.shape[1] == 0:
             return
+
+        self.idx_data = np.nan_to_num(self.idx_data, copy=True,
+                                      nan=nan_replacement)
 
         self._notifyFittingCallbacks(self.x, self.idx_data[0])
 

--- a/src/metro/devices/display/fast_plot.py
+++ b/src/metro/devices/display/fast_plot.py
@@ -542,7 +542,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         # Vertical annotation lines.
         if self.vlines is not None and self.show_annotations:
             div = self.plot_transform[0]
-            y_end = -self.plot_geometry[3]
+            y_end = int(-self.plot_geometry[3])
 
             p.save()
             p.translate(
@@ -558,8 +558,8 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
 
             for x_data, text in vlines_it:
                 if self.plot_axes[0] < x_data < self.plot_axes[1]:
-                    x_widget = x_data * div
-                    p.drawLine(x_widget, 0.0, x_widget, y_end)
+                    x_widget = int(x_data * div)
+                    p.drawLine(x_widget, 0, x_widget, y_end)
 
                     if text is not None:
                         p.drawText(p.boundingRect(
@@ -571,7 +571,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
         # Horizontal annotation lines.
         if self.hlines is not None and self.show_annotations:
             div = self.plot_transform[1]
-            x_end = self.plot_geometry[2]
+            x_end = int(self.plot_geometry[2])
 
             p.save()
             p.translate(
@@ -587,8 +587,8 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
 
             for y_data, text in hlines_it:
                 if self.plot_axes[2] < y_data < self.plot_axes[3]:
-                    y_widget = -y_data * div
-                    p.drawLine(0.0, y_widget, x_end, y_widget)
+                    y_widget = int(-y_data * div)
+                    p.drawLine(0, y_widget, x_end, y_widget)
 
                     if text is not None:
                         p.drawText(p.boundingRect(
@@ -791,7 +791,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
     def _buildAxisLabel(self, value, x, y, p, flags):
         text = str(value)
 
-        r = p.boundingRect(x, y, 1, 1, flags, text)
+        r = p.boundingRect(int(x), int(y), 1, 1, flags, text)
         r._flags = flags
         r._str = text
 

--- a/src/metro/devices/display/fast_plot.py
+++ b/src/metro/devices/display/fast_plot.py
@@ -1264,15 +1264,19 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
                 self.idx_data = self.idx_data[1:]
             else:
                 self.x = np.arange(self.idx_data.shape[1])
-
+            # TODO: option to drop instead of replace
             self.x_label = self.y_label = self.legend_entries = \
                 self.vlines = self.hlines = None
 
         if self.idx_data.shape[1] == 0:
             return
 
+        # infinity replaced with very positive / negative values
+        finite_mask = np.isfinite(self.idx_data)
         self.idx_data = np.nan_to_num(self.idx_data, copy=True,
-                                      nan=nan_replacement)
+                                      nan=nan_replacement,
+                                      posinf=1e10,
+                                      neginf=-1e10)
 
         self._notifyFittingCallbacks(self.x, self.idx_data[0])
 
@@ -1303,8 +1307,9 @@ class Device(metro.WidgetDevice, metro.DisplayDevice, fittable_plot.Device):
             self.plot_axes[1] = x_max + x_pad
 
         if self.autoscale_y:
-            y_min = self.idx_data.min()
-            y_max = self.idx_data.max()
+            data_for_scale = self.idx_data[finite_mask]
+            y_min = data_for_scale.min()
+            y_max = data_for_scale.max()
 
             y_pad = (y_max - y_min) * 0.02
 

--- a/src/metro/devices/display/hist2d.py
+++ b/src/metro/devices/display/hist2d.py
@@ -271,8 +271,9 @@ class DetectorImageWidget(QtWidgets.QWidget):
 
             polygon = self.x_spectrum_polygon
             for i in range(0, n_points):
-                polygon.setPoint(i, i / x_scale,
-                                 145 - int(x_spectrum[x_min+i] / y_scale))
+                polygon.setPoint(
+                    i, int(i / x_scale),
+                    145 - int(x_spectrum[x_min+i] / y_scale))
 
             qp.drawPolyline(polygon)
 
@@ -291,14 +292,14 @@ class DetectorImageWidget(QtWidgets.QWidget):
             x_scale = y_spectrum_max / 85
             y_scale = n_points / self.data_img_dest.height()
 
-            x_offset = 5 + self.data_img_dest.right()
+            x_offset = 5 + int(self.data_img_dest.right())
 
             polygon = self.y_spectrum_polygon
             for i in range(0, n_points):
                 polygon.setPoint(
-                    i, x_offset + int(y_spectrum[y_min+i] / x_scale),
-                    150 + self.data_img_dest.height() - i / y_scale
-                )
+                    i,
+                    x_offset + int(y_spectrum[y_min+i] / x_scale),
+                    150 + int(self.data_img_dest.height() - i / y_scale))
 
             qp.drawPolyline(polygon)
 
@@ -347,12 +348,12 @@ class DetectorImageWidget(QtWidgets.QWidget):
 
         for label, line in zip(self.axes_tick_x_labels,
                                self.axes_tick_x_lines):
-            qp.drawText(line.x1()-40, line.y1()-20, 80, 20,
+            qp.drawText(int(line.x1()) - 40, int(line.y1()) - 20, 80, 20,
                         QtCore.Qt.AlignCenter, str(label))
 
         for label, line in zip(self.axes_tick_y_labels,
                                self.axes_tick_y_lines):
-            qp.drawText(line.x1()+10, line.y1()-10, 80, 20,
+            qp.drawText(int(line.x1()) + 10, int(line.y1()) - 10, 80, 20,
                         QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter,
                         str(label))
 
@@ -524,8 +525,8 @@ class DetectorImageWidget(QtWidgets.QWidget):
 
             coords = roi['coords']
 
-            roi_x = s_x * (coords[0] - self.axes['x_min'])
-            roi_y = s_y * (self.axes['y_max'] - coords[3])
+            roi_x = int(s_x * (coords[0] - self.axes['x_min']))
+            roi_y = int(s_y * (self.axes['y_max'] - coords[3]))
 
             top_visible = bottom_visible = left_visible = right_visible = True
 
@@ -543,8 +544,8 @@ class DetectorImageWidget(QtWidgets.QWidget):
                 top_visible = False
                 roi_y = img_height
 
-            roi_width = s_x * (coords[2] - coords[0])
-            roi_height = s_y * (coords[3] - coords[1])
+            roi_width = int(s_x * (coords[2] - coords[0]))
+            roi_height = int(s_y * (coords[3] - coords[1]))
 
             if (roi_x + roi_width) > img_width:
                 right_visible = False
@@ -1343,8 +1344,8 @@ class DetectorImageWidget(QtWidgets.QWidget):
         mx_60 = max_value * 0.6 + z_min
         mx_80 = max_value * 0.8 + z_min
 
-        color_table = [QtGui.qRgb(255.0, 255.0, 255.0)] * 256
-        color_table[0] = QtGui.qRgb(0.0, 0.0, 0.0)
+        color_table = [QtGui.qRgb(255, 255, 255)] * 256
+        color_table[0] = QtGui.qRgb(0, 0, 0)
 
         grad = QtGui.QLinearGradient()
         grad.setStart(0, 0)
@@ -1382,8 +1383,7 @@ class DetectorImageWidget(QtWidgets.QWidget):
                 blue = (i - mx_80) / (max_value - mx_80)  # rising
 
             color_table[i] = QtGui.qRgb(
-                red * 255.0, green * 255.0, blue * 255.0
-            )
+                int(red * 255.0), int(green * 255.0), int(blue * 255.0))
             grad.setColorAt(1.0 - (i / max_value),
                             QtGui.QColor.fromRgb(color_table[i]))
 

--- a/src/metro/devices/display/waveform.py
+++ b/src/metro/devices/display/waveform.py
@@ -237,6 +237,9 @@ class Device(single_plot.Device, metro.DisplayDevice):
         except TypeError:
             pass
 
+        if not numpy.isfinite(d):
+            return
+
         try:
             self.y_data.append(d)
             self.ma_buffer.append(d)

--- a/src/metro/devices/util/simulate/scalar_abstract.py
+++ b/src/metro/devices/util/simulate/scalar_abstract.py
@@ -18,7 +18,7 @@ class Operator(async_operator.Operator):
         self.offset = args['offset']
 
         self.timer = metro.QTimer(self)
-        self.timer.setInterval(args['interval'] * 1000)
+        self.timer.setInterval(int(args['interval'] * 1000))
         self.timer.timeout.connect(self.tick)
 
     def finalize(self):

--- a/src/metro/devices/util/simulate/scalar_manual.py
+++ b/src/metro/devices/util/simulate/scalar_manual.py
@@ -24,7 +24,7 @@ class Device(metro.WidgetDevice):
         self.offset = args['offset']
 
         self.timer = metro.QTimer(self)
-        self.timer.setInterval(args['interval'] * 1000)
+        self.timer.setInterval(int(args['interval'] * 1000))
         self.timer.timeout.connect(self.tick)
 
         self.measure_connect(self.measuringStarted, self.measuringStopped)


### PR DESCRIPTION
As I'm not very familiar with the code base yet, I'll just post this to record which parts I've gotten to so far. In any plot, one should decide between replacing nan with some value or dropping it. Same goes for +-infinity values.

Have so far looked at:

- [ ] `fast_plot`
  - [x] `ndarray` with `ndim==1`
  - [ ] `ndarray` with `ndim>1`
  - [ ] `ndarray` with `ndim>1` and `self.with_x`
  - [ ] `xr.DataArray`
- [ ] `hist1d`
- [ ] `hist2d`
- [x] `image`
  - Already just works (on my machine)
- [ ] `plot`
- [ ] `polar_plot`
- [ ] `sorted`
- [ ] `value`
- [x] `waveform`

Developing against `fix/forward-compat` as that allowed me to install locally for testing, but can (rebase and) switch to point to `master` later.