### PR TITLE
No longer sort dicts when using pprint in display.value

### DIFF
--- a/src/metro/devices/display/value.py
+++ b/src/metro/devices/display/value.py
@@ -44,7 +44,7 @@ class Device(metro.WidgetDevice, metro.DisplayDevice):
         elif args['func'] == 'pprint':
             import pprint
 
-            pretty_printer = pprint.PrettyPrinter(indent=4)
+            pretty_printer = pprint.PrettyPrinter(indent=4, sort_dicts=False)
             self.display_func = pretty_printer.pformat
         elif args['func'] == 'ndshape':
             self.display_func = lambda x: str(x.shape)


### PR DESCRIPTION
Unless we need to sort it, keep it unsorted. It could become an option.